### PR TITLE
Add squad assets for slotting board

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -938,6 +938,7 @@
     "slotAccessPriority": "أولوية",
     "slotAccessRegular": "عادي",
     "slotUnclaimed": "شاغر",
+    "squadAssets": "معدات: {count}",
     "yourSlot": "خانتك",
     "claimSlot": "حجز الخانة",
     "switchHere": "الانتقال إلى هنا",

--- a/messages/en.json
+++ b/messages/en.json
@@ -938,6 +938,7 @@
     "slotAccessPriority": "Priority",
     "slotAccessRegular": "Regular",
     "slotUnclaimed": "Unclaimed",
+    "squadAssets": "Assets: {count}",
     "yourSlot": "Your slot",
     "claimSlot": "Claim slot",
     "switchHere": "Switch here",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -938,6 +938,7 @@
     "slotAccessPriority": "Приоритет",
     "slotAccessRegular": "Обычный",
     "slotUnclaimed": "Свободно",
+    "squadAssets": "Техника: {count}",
     "yourSlot": "Ваш слот",
     "claimSlot": "Занять слот",
     "switchHere": "Перейти сюда",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -936,6 +936,7 @@
     "slotAccessPriority": "Пріоритет",
     "slotAccessRegular": "Звичайний",
     "slotUnclaimed": "Вільно",
+    "squadAssets": "Техніка: {count}",
     "yourSlot": "Ваш слот",
     "claimSlot": "Зайняти слот",
     "switchHere": "Перейти сюди",

--- a/src/features/games/domain/slotting.ts
+++ b/src/features/games/domain/slotting.ts
@@ -24,10 +24,19 @@ export const slotSchema = z.object({
 	occupant: slotOccupantSchema
 });
 
+// Hardware attached to a squad in the game lobby — trucks, helicopters, tanks,
+// static weapons (informational, not claimable). Optional so slotting JSON
+// persisted before assets existed keeps parsing.
+export const squadAssetSchema = z.object({
+	id: z.string().trim().min(1),
+	name: z.string().trim().min(1)
+});
+
 export const squadSchema = z.object({
 	id: z.string().trim().min(1),
 	name: z.string().trim().min(1),
-	slots: z.array(slotSchema)
+	slots: z.array(slotSchema),
+	assets: z.array(squadAssetSchema).optional()
 });
 
 export const sideSchema = z.object({
@@ -45,6 +54,7 @@ export const canonicalSlottingSchema = z.object({
 export type CanonicalSlotting = z.infer<typeof canonicalSlottingSchema>;
 export type CanonicalSlot = z.infer<typeof slotSchema>;
 export type CanonicalSlotOccupant = z.infer<typeof slotOccupantSchema>;
+export type CanonicalSquadAsset = z.infer<typeof squadAssetSchema>;
 
 type CanonicalSide = CanonicalSlotting['sides'][number];
 type CanonicalSquad = CanonicalSide['squads'][number];

--- a/src/features/games/ui/GameMissionPage.tsx
+++ b/src/features/games/ui/GameMissionPage.tsx
@@ -27,6 +27,7 @@ import {
 	ConnectionSegment,
 	CountdownSegment,
 	SlotCell,
+	SquadAssetsBadge,
 	SyncedHorizontalScroll
 } from './missionPageComponents';
 import { useMissionGuide, MissionGuideModal } from './MissionGuideModal';
@@ -1207,8 +1208,9 @@ function SlottingBoards({
 											#
 										</th>
 										{side.squads.map((squad) => (
-											<th key={squad.id} className="border-b border-neutral-800 bg-neutral-950/80 px-3 py-3 text-left align-bottom">
+											<th key={squad.id} className="border-b border-neutral-800 bg-neutral-950/80 px-3 py-3 text-left align-top">
 												<div className="text-sm font-semibold uppercase tracking-[0.2em] text-neutral-300">{squad.name}</div>
+												<SquadAssetsBadge assets={squad.assets ?? []} t={t} />
 											</th>
 										))}
 									</tr>

--- a/src/features/games/ui/SlottingEditor.tsx
+++ b/src/features/games/ui/SlottingEditor.tsx
@@ -15,7 +15,7 @@ import {
 	slotBadgeClass,
 	slottingTableWidthRem
 } from './missionPageUtils';
-import { SyncedHorizontalScroll } from './missionPageComponents';
+import { SquadAssetsBadge, SyncedHorizontalScroll } from './missionPageComponents';
 
 const ACCESS_VALUES: Array<CanonicalSlot['access']> = ['unit', 'priority', 'regular'];
 
@@ -111,8 +111,9 @@ export function SlottingEditor({ slotting, slottingRevision, unitAssignments, mi
 											#
 										</th>
 										{side.squads.map((squad) => (
-											<th key={squad.id} className="border-b border-neutral-800 bg-neutral-950/80 px-3 py-3 text-left align-bottom">
+											<th key={squad.id} className="border-b border-neutral-800 bg-neutral-950/80 px-3 py-3 text-left align-top">
 												<div className="text-sm font-semibold uppercase tracking-[0.2em] text-neutral-300">{squad.name}</div>
+												<SquadAssetsBadge assets={squad.assets ?? []} t={tg} />
 											</th>
 										))}
 									</tr>

--- a/src/features/games/ui/missionPageComponents.tsx
+++ b/src/features/games/ui/missionPageComponents.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import type { useTranslations } from 'next-intl';
-import type { CanonicalSlot } from '@/features/games/domain/slotting';
+import type { CanonicalSlot, CanonicalSquadAsset } from '@/features/games/domain/slotting';
 import {
 	slotAccessLabel,
 	slotBadgeClass,
@@ -146,6 +146,73 @@ export function CountdownSegment({ value, label }: { value: string; label: strin
 				<span className="text-2xl font-semibold text-neutral-50 sm:text-3xl">{value}</span>
 				<span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-neutral-400 sm:text-xs">{label}</span>
 			</div>
+		</div>
+	);
+}
+
+export function SquadAssetsBadge({
+	assets,
+	t
+}: {
+	assets: CanonicalSquadAsset[];
+	t: ReturnType<typeof useTranslations<'games'>>;
+}) {
+	const [open, setOpen] = useState(false);
+	const rootRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		const onPointerDown = (event: PointerEvent) => {
+			if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+				setOpen(false);
+			}
+		};
+		document.addEventListener('pointerdown', onPointerDown);
+		return () => document.removeEventListener('pointerdown', onPointerDown);
+	}, [open]);
+
+	if (assets.length === 0) return null;
+
+	return (
+		<div ref={rootRef} className="relative mt-1">
+			<button
+				type="button"
+				onClick={() => setOpen((value) => !value)}
+				className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] transition ${
+					open
+						? 'border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
+						: 'border-neutral-700 bg-white/5 text-neutral-400 hover:border-neutral-500 hover:text-neutral-200'
+				}`}
+			>
+				{t('squadAssets', { count: assets.length })}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 20 20"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth={2}
+					className={`h-2.5 w-2.5 transition-transform ${open ? 'rotate-180' : ''}`}
+					aria-hidden="true"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" d="m6 8 4 4 4-4" />
+				</svg>
+			</button>
+
+			{open ? (
+				<div className="absolute left-0 top-full z-40 mt-1 min-w-full max-w-64 rounded-xl border border-neutral-700 bg-neutral-950 p-2 shadow-xl shadow-black/40">
+					<ul className="grid gap-1.5">
+						{assets.map((asset) => (
+							<li
+								key={asset.id}
+								className="flex items-start gap-2 whitespace-normal break-words text-xs font-medium normal-case tracking-normal text-neutral-200 [overflow-wrap:anywhere]"
+							>
+								<span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[color:var(--accent)]/70" aria-hidden="true" />
+								<span>{asset.name}</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			) : null}
 		</div>
 	);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Squad headers now display the number of available assets.
  * Select the asset badge to view a dropdown listing asset names.
  * Asset information is available in Arabic, English, Russian, and Ukrainian.
* **UI Improvements**
  * Squad headers have been adjusted to accommodate asset details.
  * Asset details automatically remain hidden when no assets are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->